### PR TITLE
chore: upgrade Lucene to 10.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/org.codelibs/analyzers.svg?label=Maven%20Central)](https://central.sonatype.com/search?q=g%3Aorg.codelibs%20a%3Aanalyzers)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-A comprehensive Java library providing extended Lucene analyzers with specialized support for Japanese and English text processing. Built on Apache Lucene 10.2.2 with Java 21 compatibility.
+A comprehensive Java library providing extended Lucene analyzers with specialized support for Japanese and English text processing. Built on Apache Lucene 10.5.0 with Java 21 compatibility.
 
 ## 🚀 Features
 
@@ -37,20 +37,20 @@ A comprehensive Java library providing extended Lucene analyzers with specialize
 <dependency>
     <groupId>org.codelibs</groupId>
     <artifactId>analyzers</artifactId>
-    <version>10.2.2.0</version>
+    <version>10.4.0.0</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```gradle
-implementation 'org.codelibs:analyzers:10.2.2.0'
+implementation 'org.codelibs:analyzers:10.4.0.0'
 ```
 
 ## 🏗️ Requirements
 
 - **Java**: 21 or higher
-- **Apache Lucene**: 10.2.2
+- **Apache Lucene**: 10.5.0
 - **Maven**: 3.6+ (for building from source)
 
 ## 🔧 Usage Examples
@@ -185,5 +185,5 @@ Licensed under the Apache License, Version 2.0. See [LICENSE](http://www.apache.
 
 The version number follows Lucene's versioning scheme with an additional patch level:
 - Format: `{lucene.version}.{patch}`
-- Current: `10.2.2.0` (based on Lucene 10.2.2)
+- Latest release: `10.4.0.0` (based on Lucene 10.4.0)
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs</groupId>
 	<artifactId>analyzers</artifactId>
-	<version>10.4.0.1-SNAPSHOT</version>
+	<version>10.5.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This library provides Lucene's analyzers for Japanese.</description>
 	<inceptionYear>2011</inceptionYear>
@@ -36,7 +36,7 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<lucene.version>10.4.0</lucene.version>
+		<lucene.version>10.5.0</lucene.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<build>


### PR DESCRIPTION
## Summary

Upgrades the Apache Lucene dependency from 10.4.0 to 10.5.0 and bumps the project version to `10.5.0.0-SNAPSHOT`, following the existing `{lucene.version}.{patch}` scheme.

No source changes are required — 10.5.0 is a drop-in replacement for this library.

## Verification

Rather than relying on a green build alone, the upgrade was checked against the actual upstream changes:

- **Lucene 10.5.0 `CHANGES.txt`** — the only analysis-module entries are `HTMLStripCharFilter`, `TruncateTokenFilter` and the hyphenation `PatternParser`. None are used here. 10.5.0 has no Deprecations section.
- **Upstream classes this library derives from** — `JapaneseNumberFilter` (→ `KanjiNumberFilter`), `PorterStemmer` (→ `FlexiblePorterStemmer`), `JapaneseIterationMarkCharFilter` (→ `IterationMarkCharFilter`) and `KeywordMarkerFilter` are all byte-identical between the 10.4.0 and 10.5.0 tags, so there are no upstream fixes to port.
- **Test framework** — `BaseTokenStreamTestCase`, `MockTokenizer` and kuromoji's `UserDictionary` differ only cosmetically (`toArray(new String[0])` → `toArray(String[]::new)`); no behavioural or assertion changes that could affect these tests.
- **Build** — `mvn clean package` succeeds with 102/102 tests passing, and compiling with `-Xlint:deprecation` produces no warnings.

## README

The README still advertised Lucene 10.2.2, two releases behind. The Lucene version now matches what the project builds against, and the Maven/Gradle install snippets point at `10.4.0.0`, the latest version actually published to Maven Central.

## Note: pre-existing bug found (not addressed here)

While testing beyond the pinned `tests.seed=DEADBEEF`, seed `F16E4B4DD04D53FE` reproduces two failures:

```
AlphaNumWordFilterTest.testBasic        term 0 expected:<[aaa]> but was:<[b]>
NumberConcatenationFilterTest.testBasic term 0 expected:<1[]> but was:<1[00]>
```

This is **not a regression from this upgrade** — the same seed fails identically on 10.4.0.

Root cause: `ConcatenationFilter` and `AlphaNumWordFilter` both buffer a lookahead token in a `State current` field but neither overrides `reset()` to clear it. When the analyzer instance is reused — which `BaseTokenStreamTestCase.checkAnalysisConsistency` exercises only on some seeds — the stale token left over from the previous stream is emitted at the start of the next one. It affects `NumberConcatenationFilter`, `PatternConcatenationFilter`, `PosConcatenationFilter` and `AlphaNumWordFilter`.

Left out of this PR to keep the dependency bump separate from a behavioural fix; worth a follow-up.
