### PR TITLE
build: attach sources and javadoc jars explicitly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,19 @@
 				</executions>
 			</plugin>
 			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.3.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.11.2</version>
 				<configuration>
@@ -89,6 +102,15 @@
 					<docencoding>UTF-8</docencoding>
 					<charset>UTF-8</charset>
 				</configuration>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>com.mycila</groupId>


### PR DESCRIPTION
## Summary

The 10.5.0.0 release deployment was rejected by Maven Central with:

```
- Sources must be provided but not found in entries
- Javadocs must be provided but not found in entries
```

The build never declared maven-source-plugin, and maven-javadoc-plugin only had a `<configuration>` block with no `<executions>`. Both jars were produced solely by the super POM's `release-profile`, which is activated by the `performRelease` property.

maven-release-plugin 3.0.1 changed the default of `useReleaseProfile` from `true` to `false` and marked it deprecated ("The release-profile profile will be removed from future versions of the super POM"). As a result `release:perform` no longer sets `performRelease=true`, the profile never activated, and the deployment went out without the sources and javadoc jars.

Since that profile is on its way out of the super POM anyway, this declares both executions explicitly instead of restoring the deprecated flag.

## Changes Made

- Added `maven-source-plugin` 3.3.1 with the `jar-no-fork` goal bound to the `package` phase.
- Added an `attach-javadocs` execution (`jar` goal, `package` phase) to the existing `maven-javadoc-plugin` block. Its current `<configuration>` is left untouched.

Both jars are now built on every `package`, so they no longer depend on how the release plugin is invoked.

## Testing

`mvn -B clean package -DskipTests` succeeds and produces all three artifacts:

```
analyzers-10.5.0.0-SNAPSHOT.jar          31,856 bytes
analyzers-10.5.0.0-SNAPSHOT-sources.jar  34,192 bytes (29 entries)
analyzers-10.5.0.0-SNAPSHOT-javadoc.jar 208,549 bytes (89 entries)
```

Javadoc generation completes without errors under JDK 21.

## Breaking Changes

None. This only adds artifacts to the build output.

## Additional Notes

- `maven-gpg-plugin` is bound to `verify`, which runs after `package`, so the new sources and javadoc jars are picked up and signed along with the main jar — no extra configuration needed.
- The failed deployment still sitting in the Central Portal should be dropped before retrying the release.
- Other CodeLibs projects published to Central (corelib, curl4j, ...) have the same gap and will hit this on their next release.
